### PR TITLE
WIP: miscellaneous

### DIFF
--- a/semant.sml
+++ b/semant.sml
@@ -57,7 +57,7 @@ struct
        | ty2 => if tyEq(ty, ty2) then ty (* TODO *)
                    else (ErrorMsg.error p "thenExp returns different types from elseExp."; {exp=(), ty=T.UNIT})
 
-  fun tyCheckRecord(symTyPairs, tenv) =
+  fun tyCheckRecordTy(symTyPairs, tenv) =
     let fun helper tenv {name, escape, typ, pos} =
           case S.look(tenv, typ) of
              SOME v => (name, v)
@@ -78,7 +78,7 @@ struct
                                  | NONE => (ErrorMsg.error pos ("Cannot find type\
                                  \: " ^ S.name(symbol) ^ " in array declaration"); 
                                  T.UNIT))
-     | A.RecordTy(symTyPairs) => T.RECORD(tyCheckRecord(symTyPairs, tenv), ref ())
+     | A.RecordTy(symTyPairs) => T.RECORD(tyCheckRecordTy(symTyPairs, tenv), ref ())
 
   fun tyCheckArrayExp (arrSym, tenv: tenv, typeSize: expty, typeInit: expty, pos) =
     let val elementType: T.ty = case S.look(tenv, arrSym) of

--- a/semant.sml
+++ b/semant.sml
@@ -138,6 +138,7 @@ struct
               end
           | A.ArrayExp{typ, size, init, pos} =>
               tyCheckArrayExp(typ, tenv, trexp(size), trexp(init), pos)
+          | A.VarExp var => trvar var
           | _ => (ErrorMsg.error 0 "Does not match any exp" ; {exp=(), ty=T.UNIT}) (* redundant? *)
         and trvar (A.SimpleVar(varname,pos)) =
           (case Symbol.look (venv, varname) of

--- a/testcases_typechecking/t31.tig
+++ b/testcases_typechecking/t31.tig
@@ -3,7 +3,7 @@ motivation: testing record creation
 */
 let
   type rec = {a: int, b: string}
-  var r: rec := {a=5, b="love"}
+  var r: rec := rec{a=5, b="love"}
 in
   5
 end

--- a/testcases_typechecking/t32.tig
+++ b/testcases_typechecking/t32.tig
@@ -5,7 +5,7 @@ Order needs to be the same. Should report error.
 */
 let
   type rec = {a: int, b: string}
-  var r: rec := {b="love", a=5}
+  var r: rec := rec{b="love", a=5}
 in
   5
 end

--- a/testcases_typechecking/t34.tig
+++ b/testcases_typechecking/t34.tig
@@ -1,9 +1,9 @@
 /* OpExp : string comparison */
 let 
-  var s1 = "LOVE"
-  var s2 = "LOVE:
-  var b = s1 = s2
+  var s1 := "LOVE"
+  var s2 := "LOVE"
+  var b := s1 = s2
 in 
-  5
+  b
 end
 

--- a/testcases_typechecking/t39.tig
+++ b/testcases_typechecking/t39.tig
@@ -1,0 +1,6 @@
+/* VarExp */
+let
+  var a := 3
+in
+  b
+end

--- a/testcases_typechecking/t40.tig
+++ b/testcases_typechecking/t40.tig
@@ -1,0 +1,11 @@
+/* VarExp: SubscriptVar 
+  1. var is of array type 
+  2. subscript is of int type
+
+*/
+let 
+  type intArray = array of int 
+  var intArr: intArray := intArray [5] of 0
+in
+  intArr[3]
+end

--- a/testcases_typechecking/t41.tig
+++ b/testcases_typechecking/t41.tig
@@ -1,0 +1,12 @@
+/* VarExp: SubscriptVar 
+  1. var is of array type 
+  2. subscript is of int type
+
+*/
+let 
+  type intArray = array of int 
+  var intAr := 5
+  var intArr: intArray := intArray [5] of 0
+in
+  intAr[3] /* expecting errors */
+end

--- a/testcases_typechecking/t42.tig
+++ b/testcases_typechecking/t42.tig
@@ -4,11 +4,12 @@
 let 
   type rec1 = {a:int, b:string}
   type rec2 = {a:int, b:string, c:int}
-  var r1 := rec2{a=5, b="s", c=3}
+  type rec3 = {}
   var r2 := rec1{a=5, b="s"}
-  var r3: rec1 := nil
+  var r1 := rec2{a=5, b="s", c=3}
+  var r3 := rec3{}
   var r4 := nil
-  var r5 := rec3{a=5, b="s", c=3} /* error rec is not defined */
+  var r5 := rec4{a=5, b="s", c=3} /* error rec is not defined */
 in 
   5
 end

--- a/testcases_typechecking/t42.tig
+++ b/testcases_typechecking/t42.tig
@@ -1,0 +1,14 @@
+/* RecordExp 
+
+*/
+let 
+  type rec1 = {a:int, b:string}
+  type rec2 = {a:int, b:string, c:int}
+  var r1 := rec2{a=5, b="s", c=3}
+  var r2 := rec1{a=5, b="s"}
+  var r3: rec1 := nil
+  var r4 := nil
+  var r5 := rec3{a=5, b="s", c=3} /* error rec is not defined */
+in 
+  5
+end

--- a/testcases_typechecking/t43.tig
+++ b/testcases_typechecking/t43.tig
@@ -1,0 +1,16 @@
+/* RecordExp: NilExp 
+
+As specified in Appel, Andrew W.. Modern Compiler Implementation in ML (Kindle Location 10757). Cambridge University Press. Kindle Edition. 
+
+*/
+let 
+  type my_record = {a:int, b:string}
+  var a : my_record := nil  /* OK */
+  a := nil                  /* OK */
+  function f(p: my_record) = p
+  var b := nil   /*illegal*/
+in 
+  if a = nil then ();  /* OK */
+  if nil <> a then (); /* OK */
+  f(nil)  /* OK */
+end

--- a/testcases_typechecking/t44.tig
+++ b/testcases_typechecking/t44.tig
@@ -1,0 +1,9 @@
+/* RecordExp 
+
+*/
+let 
+  type rec1 = {a:int, b:string}
+  var r2:rec1 := nil
+in 
+  5
+end

--- a/testcases_typechecking/t45.tig
+++ b/testcases_typechecking/t45.tig
@@ -1,0 +1,10 @@
+/* RecordExp 
+
+*/
+let 
+  type rec1 = {a:int, b:string}
+  var r1 := rec1{a=5, b="s", c=3}
+  var r2 := rec1{aa=5, b="s", c=3}
+in 
+  5
+end

--- a/types.sml
+++ b/types.sml
@@ -11,4 +11,14 @@ struct
           | ARRAY of ty * unique
           | NAME of Symbol.symbol * ty option ref
           | UNIT
+
+  fun nameTy ty =
+    case ty of
+      RECORD(_) =>"record"
+    | NIL =>  "record: nil"
+    | INT => "int"
+    | STRING => "string"
+    | ARRAY(_) =>  "array"
+    | NAME(symbol, r) => Symbol.name symbol
+    | UNIT => "unit"
 end


### PR DESCRIPTION
TODO

**Function calls**
- [ ]  ID LPAREN exp_list RPAREN            <A.CallExp>

**while**
- [x] WHILE exp DO exp  (9ad5ef7 and 1b37589)
- [ ]  BREAK     -- for while loop

**for**
- [ ]  FOR ID ASSIGN exp TO exp DO exp      A.ForExp({v
- [ ]  BREAK     -- for for loop         

**Let/decs**
- [ ]  LET decs IN exp END                  (Recursive Declaration)
- [ ]  funDec <non-recursive and recursive
- [ ]  cyclic type declarations (t23.tig)
**VarExp**
- [ ]  lval                                 A.VarExp

**Others**
- [x]  ID LBRACE record_fields RBRACE       A.RecordExp (t31.tig, t32.tig)
- [ ]  OpExp: record comparison     
- [ ]  exp AND exp        <-implemented using if else 
- [ ]  exp OR exp           <-implemented using if else              
- [ ] nil  - Appel, Andrew W.. Modern Compiler Implementation in ML (Kindle Location 10757). Cambridge University Press. Kindle Edition.  
- [ ] nil  - NilExp : var r: rec := nil
- [ ] actual_ty 
### Reference

**Record creation:** The expression type-id {id=exp{, id=exp}} or (for an empty record type) type-id { } creates a new record instance of type type-id. The field names and types of the record expression must match those of the named type, in the order given. The braces { } stand for themselves.

**Array creation:** The expression type-id [exp1] of exp2 evaluates exp1 and exp2 (in that order) to find n, the number of elements, and v the initial value. The type type-id must be declared as an array type. The result of the expression is a new array of type type-id, indexed from 0 to n – 1, in which each slot is initialized to the value v. 

**Array and record assignment:** When an array or record variable a is assigned a value b, then a references the same array or record as b. Future updates of elements of a will affect b, and vice versa, until a is reassigned. Parameter passing of arrays and records is similarly by reference, not by copying. 

**Extent:** Records and arrays have infinite extent: each record or array value lasts forever, even after control exits from the scope in which it was created. 

**Assignment:** The assignment statement lvalue : = exp evaluates the lvalue, then evaluates the exp, then sets the contents of the lvalue to the result of the expression. Syntactically, : = binds weaker than the boolean operators & and |. The assignment expression produces no value, so that (a:=b)+c is illegal.

Appel, Andrew W.. Modern Compiler Implementation in ML (Kindle Locations 10805-10820). Cambridge University Press. Kindle Edition. 
